### PR TITLE
Plugin property fix

### DIFF
--- a/src/main/java/net/pms/configuration/PmsConfiguration.java
+++ b/src/main/java/net/pms/configuration/PmsConfiguration.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import net.pms.io.SystemUtils;
+import net.pms.util.PropertiesUtil;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
@@ -1817,7 +1818,7 @@ public class PmsConfiguration {
 	}
 
 	public String getPluginDirectory() {
-		return getString(KEY_PLUGIN_DIRECTORY, "plugins");
+		return getString(KEY_PLUGIN_DIRECTORY, PropertiesUtil.getProjectProperties().get("project.plugins.dir"));
 	}
 
 	public void setPluginDirectory(String value) {

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -2,6 +2,7 @@
 project.name=${project.name}
 project.version=${project.version}
 #project.renderers.dir=renderers
+project.plugins.dir=plugins
 project.renderers.dir=renderers, src/main/external-resources/renderers
 project.binaries.dir=
 project.logback=logback.xml

--- a/src/test/resources/project.properties
+++ b/src/test/resources/project.properties
@@ -1,6 +1,7 @@
 # PMS specific project properties
 project.name=${project.name}
 project.version=${project.version}
+project.plugins.dir=src/main/external-resources/plugins
 project.renderers.dir=src/main/external-resources/renderers
 project.binaries=${project.binaries}
 project.logback=src/main/external-resources/logback.xml


### PR DESCRIPTION
This makes the plugins directory found when running from Eclipse.
I got a configuration error after fixing it:

```
 Configuration error: net/pms/medialibrary/external/DlnaTreeFolderPlugin
```

Not sure how to solve that one, or what it means. :-)
