### PR TITLE
First things based on stackoverflows information

### DIFF
--- a/plugins/FileSystemDlnaFolderPlugin/pom.xml
+++ b/plugins/FileSystemDlnaFolderPlugin/pom.xml
@@ -3,25 +3,15 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>FileSystemFolderPlugin</artifactId>
-	<version>3-SNAPSHOT</version>
-	<packaging>jar</packaging>
-	<description>Plugin which will merge all configured file system folders into one.</description>
-
-	<parent>
+	
+  <parent>
 		<groupId>net.pms</groupId>
 		<artifactId>pms-plugins</artifactId>
 		<version>1.52.1_mlx_v0.8-SNAPSHOT</version>
 	</parent>
 
-	<licenses>
-		<license>
-			<name>GNU General Public License version 2</name>
-			<url>http://www.gnu.org/licenses/gpl-2.0.txt</url>
-			<distribution>manual</distribution>
-		</license>
-	</licenses>
-
+	<artifactId>FileSystemFolderPlugin</artifactId>
+	<description>Plugin which will merge all configured file system folders into one.</description>
 
 	<properties>
 		<finalName>FileSystemFolderPlugin-${version}</finalName>
@@ -31,14 +21,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>

--- a/plugins/ImdbMovieImportPlugin/pom.xml
+++ b/plugins/ImdbMovieImportPlugin/pom.xml
@@ -3,24 +3,15 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>ImdbMovieImportPlugin</artifactId>
-	<version>3-SNAPSHOT</version>
-	<packaging>jar</packaging>
-
-	<parent>
+	
+  <parent>
 		<groupId>net.pms</groupId>
 		<artifactId>pms-plugins</artifactId>
 		<version>1.52.1_mlx_v0.8-SNAPSHOT</version>
 	</parent>
 
-	<licenses>
-		<license>
-			<name>GNU General Public License version 2</name>
-			<url>http://www.gnu.org/licenses/gpl-2.0.txt</url>
-			<distribution>manual</distribution>
-		</license>
-	</licenses>
 
+	<artifactId>ImdbMovieImportPlugin</artifactId>
 
 	<properties>
 		<finalName>ImdbMovieImportPlugin-${version}</finalName>
@@ -30,14 +21,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>

--- a/plugins/PlayCountWatcherPlugin/pom.xml
+++ b/plugins/PlayCountWatcherPlugin/pom.xml
@@ -3,10 +3,6 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>PlayCountWatcherPlugin</artifactId>
-	<packaging>jar</packaging>
-	<description>Plugin used to increment play counts in the media library after a file has been played</description>
-	<version>2-SNAPSHOT</version>
 
 	<parent>
 		<groupId>net.pms</groupId>
@@ -14,14 +10,8 @@
 		<version>1.52.1_mlx_v0.8-SNAPSHOT</version>
 	</parent>
 
-	<licenses>
-		<license>
-			<name>GNU General Public License version 2</name>
-			<url>http://www.gnu.org/licenses/gpl-2.0.txt</url>
-			<distribution>manual</distribution>
-		</license>
-	</licenses>
-
+	<artifactId>PlayCountWatcherPlugin</artifactId>
+	<description>Plugin used to increment play counts in the media library after a file has been played</description>
 
 	<properties>
 		<finalName>PlayCountWatcherPlugin-${version}</finalName>
@@ -31,14 +21,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>

--- a/plugins/TmdbMovieImportPlugin/pom.xml
+++ b/plugins/TmdbMovieImportPlugin/pom.xml
@@ -3,10 +3,6 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>TmdbMovieImportPlugin</artifactId>
-	<packaging>jar</packaging>
-	<version>4-SNAPSHOT</version>
-	<description>Plugin used to import properties and tags for video files from TMDB</description>
 
 	<parent>
 		<groupId>net.pms</groupId>
@@ -14,14 +10,9 @@
 		<version>1.52.1_mlx_v0.8-SNAPSHOT</version>
 	</parent>
 
-	<licenses>
-		<license>
-			<name>GNU General Public License version 2</name>
-			<url>http://www.gnu.org/licenses/gpl-2.0.txt</url>
-			<distribution>manual</distribution>
-		</license>
-	</licenses>
+	<artifactId>TmdbMovieImportPlugin</artifactId>
 
+	<description>Plugin used to import properties and tags for video files from TMDB</description>
 
 	<properties>
 		<finalName>TmdbMovieImportPlugin-${version}</finalName>
@@ -31,14 +22,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>

--- a/plugins/TmdbRater/pom.xml
+++ b/plugins/TmdbRater/pom.xml
@@ -3,10 +3,6 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>TmdbRater</artifactId>
-	<version>2-SNAPSHOT</version>
-	<packaging>jar</packaging>
-	<description>Plugin used to rate movies on TMDB from the renderer. This plugins requires a configured TMDB account</description>
 
 	<parent>
 		<groupId>net.pms</groupId>
@@ -14,14 +10,9 @@
 		<version>1.52.1_mlx_v0.8-SNAPSHOT</version>
 	</parent>
 
-	<licenses>
-		<license>
-			<name>GNU General Public License version 2</name>
-			<url>http://www.gnu.org/licenses/gpl-2.0.txt</url>
-			<distribution>manual</distribution>
-		</license>
-	</licenses>
+	<artifactId>TmdbRater</artifactId>
 
+	<description>Plugin used to rate movies on TMDB from the renderer. This plugins requires a configured TMDB account</description>
 
 	<properties>
 		<finalName>TmdbRater-${version}</finalName>
@@ -31,14 +22,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>

--- a/plugins/VideoSettingsDlnaFolderPlugin/pom.xml
+++ b/plugins/VideoSettingsDlnaFolderPlugin/pom.xml
@@ -3,9 +3,6 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>VideoSettingsDlnaFolderPlugin</artifactId>
-	<version>3-SNAPSHOT</version>
-	<packaging>jar</packaging>
 
 	<parent>
 		<groupId>net.pms</groupId>
@@ -13,14 +10,7 @@
 		<version>1.52.1_mlx_v0.8-SNAPSHOT</version>
 	</parent>
 
-	<licenses>
-		<license>
-			<name>GNU General Public License version 2</name>
-			<url>http://www.gnu.org/licenses/gpl-2.0.txt</url>
-			<distribution>manual</distribution>
-		</license>
-	</licenses>
-
+	<artifactId>VideoSettingsDlnaFolderPlugin</artifactId>
 
 	<properties>
 		<finalName>VideoSettingsDlnaFolderPlugin-${version}</finalName>
@@ -30,14 +20,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>

--- a/plugins/WebDlnaFolderPlugin/pom.xml
+++ b/plugins/WebDlnaFolderPlugin/pom.xml
@@ -3,9 +3,6 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>WebDlnaFolderPlugin</artifactId>
-	<version>2-SNAPSHOT</version>
-	<packaging>jar</packaging>
 
 	<parent>
 		<groupId>net.pms</groupId>
@@ -13,14 +10,7 @@
 		<version>1.52.1_mlx_v0.8-SNAPSHOT</version>
 	</parent>
 
-	<licenses>
-		<license>
-			<name>GNU General Public License version 2</name>
-			<url>http://www.gnu.org/licenses/gpl-2.0.txt</url>
-			<distribution>manual</distribution>
-		</license>
-	</licenses>
-
+	<artifactId>WebDlnaFolderPlugin</artifactId>
 
 	<properties>
 		<finalName>WebDlnaFolderPlugin-${version}</finalName>
@@ -30,14 +20,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>

--- a/plugins/WebservicePlugin/pom.xml
+++ b/plugins/WebservicePlugin/pom.xml
@@ -3,9 +3,6 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>WebservicePlugin</artifactId>
-	<version>3-SNAPSHOT</version>
-	<packaging>jar</packaging>
 
 	<parent>
 		<groupId>net.pms</groupId>
@@ -13,14 +10,7 @@
 		<version>1.52.1_mlx_v0.8-SNAPSHOT</version>
 	</parent>
 
-	<licenses>
-		<license>
-			<name>GNU General Public License version 2</name>
-			<url>http://www.gnu.org/licenses/gpl-2.0.txt</url>
-			<distribution>manual</distribution>
-		</license>
-	</licenses>
-
+	<artifactId>WebservicePlugin</artifactId>
 
 	<properties>
 		<finalName>WebservicePlugin-${version}</finalName>
@@ -30,14 +20,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>

--- a/plugins/iPhotoDlnaFolderPlugin/pom.xml
+++ b/plugins/iPhotoDlnaFolderPlugin/pom.xml
@@ -3,16 +3,16 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>iPhotoDlnaFolderPlugin</artifactId>
-	<packaging>jar</packaging>
-	<version>3-SNAPSHOT</version>
-	<description>This plugin will add a folder containing the iPhoto library</description>
 
 	<parent>
 		<groupId>net.pms</groupId>
 		<artifactId>pms-plugins</artifactId>
 		<version>1.52.1_mlx_v0.8-SNAPSHOT</version>
 	</parent>
+
+	<artifactId>iPhotoDlnaFolderPlugin</artifactId>
+
+	<description>This plugin will add a folder containing the iPhoto library</description>
 
 	<licenses>
 		<license>
@@ -31,14 +31,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>

--- a/plugins/iTunesDlnaFolderPlugin/pom.xml
+++ b/plugins/iTunesDlnaFolderPlugin/pom.xml
@@ -3,9 +3,6 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>iTunesDlnaFolderPlugin</artifactId>
-	<packaging>jar</packaging>
-	<version>2-SNAPSHOT</version>
 
 	<parent>
 		<groupId>net.pms</groupId>
@@ -13,14 +10,8 @@
 		<version>1.52.1_mlx_v0.8-SNAPSHOT</version>
 	</parent>
 
-	<licenses>
-		<license>
-			<name>GNU General Public License version 2</name>
-			<url>http://www.gnu.org/licenses/gpl-2.0.txt</url>
-			<distribution>manual</distribution>
-		</license>
-	</licenses>
-
+	<description>This plugin will add a folder containing the iTunes library</description>
+	<artifactId>iTunesDlnaFolderPlugin</artifactId>
 
 	<properties>
 		<finalName>iTunesDlnaFolderPlugin-${version}</finalName>
@@ -30,14 +21,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
@@ -61,5 +44,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<description>This plugin will add a folder containing the iTunes library</description>
 </project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -2,13 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
+	<modelVersion>4.0.0</modelVersion>
+
 	<parent>
 		<groupId>net.pms</groupId>
 		<artifactId>pms-global</artifactId>
 		<version>1.52.1_mlx_v0.8-SNAPSHOT</version>
 	</parent>
 
-	<modelVersion>4.0.0</modelVersion>
 	<artifactId>pms-plugins</artifactId>
 	<packaging>pom</packaging>
 
@@ -25,11 +26,4 @@
 		<module>WebservicePlugin</module>
 	</modules>
 
-	<dependencies>
-		<dependency>
-			<groupId>net.pms</groupId>
-			<artifactId>pms-mlx</artifactId>
-			<version>1.52.1_mlx_v0.8-SNAPSHOT</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -15,13 +15,17 @@
 		After generating, the "target/site" directory will contain the reports. -->
 
 	<modelVersion>4.0.0</modelVersion>
+
+
 	<groupId>net.pms</groupId>
 	<artifactId>pms-global</artifactId>
-	<name>PS3 Media Server MLX</name>
-	<packaging>pom</packaging>
 	<version>1.52.1_mlx_v0.8-SNAPSHOT</version>
+
+	<packaging>pom</packaging>
+
 	<url>http://www.ps3mediaserver.org/</url>
 	<inceptionYear>2008</inceptionYear>
+	<name>PS3 Media Server MLX</name>
 
 	<organization>
 		<name>PS3 Media Server MLX</name>
@@ -80,15 +84,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
-	<pluginRepositories>
-		<pluginRepository>
-			<id>ossrh</id>
-			<name>Sonatype OSS Repository</name>
-			<url>http://oss.sonatype.org/content/groups/public</url>
-			<layout>default</layout>
-		</pluginRepository>
-	</pluginRepositories>
-
 	<repositories>
 		<!-- Java.net -->
 		<repository>
@@ -122,20 +117,9 @@
 			</snapshots>
 		</repository>
 
-		<!-- JBoss.org repository -->
-		<repository>
-			<id>jboss.releases</id>
-			<name>JBoss releases</name>
-			<url>https://repository.jboss.org/nexus/content/repositories/releases/</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
 	</repositories>
 
+  <dependencyManagement>
 	<dependencies>
 
 		<dependency>
@@ -357,4 +341,26 @@
 		</dependency>
 
 	</dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+     <plugins>
+			<plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+				</configuration>
+			</plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.3</version>
+			</plugin>
+     </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/ps3mediaserver/pom.xml
+++ b/ps3mediaserver/pom.xml
@@ -3,12 +3,14 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>pms-mlx</artifactId>
+
 	<parent>
 		<groupId>net.pms</groupId>
 		<artifactId>pms-global</artifactId>
 		<version>1.52.1_mlx_v0.8-SNAPSHOT</version>
 	</parent>
+
+	<artifactId>pms-mlx</artifactId>
 
 	<properties>
 		<finalName>PS3 Media Server MLX</finalName>
@@ -28,6 +30,197 @@
 
 		<maven.nsis.project.template>${project.basedir}/src/main/external-resources/nsis/project.jelly</maven.nsis.project.template>
 	</properties>
+
+
+	<dependencies>
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jcl-over-slf4j</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.jgoodies</groupId>
+			<artifactId>forms</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.beanshell</groupId>
+			<artifactId>bsh-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-configuration</groupId>
+			<artifactId>commons-configuration</artifactId>
+			<exclusions>
+				<!-- no need for commons-logging, as jcl-over-slf4j provides the impl -->
+				<exclusion>
+					<artifactId>commons-logging</artifactId>
+					<groupId>commons-logging</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-httpclient</groupId>
+			<artifactId>commons-httpclient</artifactId>
+			<exclusions>
+				<!-- no need for commons-logging, as jcl-over-slf4j provides the impl -->
+				<exclusion>
+					<artifactId>commons-logging</artifactId>
+					<groupId>commons-logging</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.sanselan</groupId>
+			<artifactId>sanselan</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+		</dependency>
+
+		<!-- originally, hamcrest-all 1.2RC2 for the artifact change, see: https://code.google.com/p/hamcrest/issues/detail?id=12#c54 
+			TODO: verify if needed -->
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-integration</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jboss.netty</groupId>
+			<artifactId>netty</artifactId>
+		</dependency>
+
+
+		<dependency>
+			<groupId>net.java.dev.rome</groupId>
+			<artifactId>rome</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jvnet.winp</groupId>
+			<artifactId>winp</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org</groupId>
+			<artifactId>jaudiotagger</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>net.java.dev.jna</groupId>
+			<artifactId>jna</artifactId>
+		</dependency>
+
+		<!-- XXX: not Mavenized: http://www.jgoodies.com/downloads/libraries.html -->
+		<dependency>
+			<groupId>com.jgoodies</groupId>
+			<artifactId>binding</artifactId>
+		</dependency>
+
+		<!-- XXX: not Mavenized: http://www.jgoodies.com/downloads/libraries.html -->
+		<dependency>
+			<groupId>com.jgoodies</groupId>
+			<artifactId>common</artifactId>
+		</dependency>
+
+		<!-- XXX: not Mavenized: http://www.jgoodies.com/downloads/libraries.html -->
+		<dependency>
+			<groupId>com.jgoodies</groupId>
+			<artifactId>looks</artifactId>
+		</dependency>
+
+		<!-- XXX: not Mavenized: http://github.com/edmund-wagner/junrar -->
+		<dependency>
+			<groupId>de.innosystec</groupId>
+			<artifactId>java-unrar</artifactId>
+		</dependency>
+
+		<!-- XXX: not Mavenized: https://code.google.com/p/cuelib/ -->
+		<dependency>
+			<groupId>jwbroek.cuelib</groupId>
+			<artifactId>cuelib</artifactId>
+		</dependency>
+
+		<!-- XXX: not Mavenized: http://sourceforge.net/projects/mediachest/ -->
+		<dependency>
+			<groupId>mediautil</groupId>
+			<artifactId>mediautil</artifactId>
+		</dependency>
+
+		<!-- XXX: not Mavenized: http://jtmdb.sourceforge.net/ -->
+		<dependency>
+			<groupId>net.sf</groupId>
+			<artifactId>jtmdb</artifactId>
+		</dependency>
+
+		<!-- XXX: not Mavenized: http://flib.sourceforge.net/JCalendar/doc/index.html -->
+		<dependency>
+			<groupId>org.freixas</groupId>
+			<artifactId>jcalendar</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.easymock</groupId>
+			<artifactId>easymock</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
 
 	<build>
 		<defaultGoal>assembly:assembly</defaultGoal>
@@ -119,12 +312,8 @@
 			</plugin>
 
 			<plugin>
+        <groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
 			</plugin>
 
 			<plugin>
@@ -155,29 +344,22 @@
 			</plugin>
 
 			<!-- Plugin to assemble a jar with dependencies -->
+      
+
 			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.2.1</version>
-				<executions>
-					<execution>
-						<id>make-jar-with-dependencies</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-						<configuration>
-							<descriptors>
-								<descriptor>${project.basedir}/src/main/assembly/jar-with-dependencies.xml</descriptor>
-							</descriptors>
-							<archive>
-								<manifest>
-									<mainClass>net.pms.PMS</mainClass>
-								</manifest>
-							</archive>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+            <archive>
+              <manifest>
+                <mainClass>net.pms.PMS</mainClass>
+              </manifest>
+            </archive>
+        </configuration>
+     </plugin>
 
 			<!-- This plugin will take care of installing the external dependencies 
 				that do not exist in a public Maven repository. That is why we store some 


### PR DESCRIPTION
configuration for maven-compiler-plugin.
- Using maven-assembly-plugin from parent via pluginManagement
  maven-assembly-plugin using pre-defined descriptor instead
  of using the self defined one.
- Added used dependencies (currently only a copy of the parent).
  Should be cleaned up.

Take a look at it cause currently the calling of the download the dependencies does not works...i'm working with maven3 ...
