### PR TITLE
Fix for PMS-MLX not starting on OSX

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1497,8 +1497,7 @@
 									<jvmVersion>1.6+</jvmVersion>
 									<!-- Options to the JVM, will be used as the value of VMOptions 
 										in Info.plist. -->
-									<vmOptions>-Xmx768M -Xss16M -Dfile.encoding=UTF-8
-										-Djava.net.preferIPv4Stack=true -jar</vmOptions>
+									<vmOptions>-Xmx768M -Xss16M -Dfile.encoding=UTF-8 -Djava.net.preferIPv4Stack=true -jar</vmOptions>
 									<dictionaryFile>${project.external-resources}/osx/Info.plist-template.xml</dictionaryFile>
 									<internetEnable>false</internetEnable>
 									<additionalClasspath />


### PR DESCRIPTION
I found what broke PMS-MLX on OSX: a newline in the Info.plist, caused by the newline in the vmOptions in the pom.xml.
Remove the newline and it works again! :-)
